### PR TITLE
fix: make random nonce generation work on OS X

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -64,7 +64,7 @@ rm requestheaders
 set +b
 echo ""
 
-NONCE=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+NONCE=$(cat /dev/urandom | base64 | fold -w 8 | head -n 1)
 echo "testing http with nonce: ${NONCE}"
 IP=$(curl -q -s ifconfig.co)
 sed "s/NONCE/${NONCE}/g" http.jpg > http1.jpg


### PR DESCRIPTION
`tr` util behaves differently on osx, erring with `tr: Illegal byte sequence`.
use base64 instead.
