### PR TITLE
Use colon as delimiter to allow forward slashes in nonce

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -67,7 +67,7 @@ echo ""
 NONCE=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 echo "testing http with nonce: ${NONCE}"
 IP=$(curl -q -s ifconfig.co)
-sed "s/NONCE/${NONCE}/g" http.jpg > http1.jpg
+sed "s:NONCE:${NONCE}:g" http.jpg > http1.jpg
 #echo "#### identify ######"
 identify http1.jpg 2>/dev/null 1>/dev/null
 #echo "####################"


### PR DESCRIPTION
Nonce containing a forward slash throws the following error if `/` is used as the delimiter for `sed`:

```
testing http with nonce: xxC1A0b/
sed: -e expression #1, char 17: unknown option to `s'
```

An easy fix is to use a different delimiter, e.g. `:`
